### PR TITLE
Simplify matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,17 +27,17 @@ matrix:
     - env: TOX_SUFFIX="aiohttp"
       python: "pypy"
 python:
-- "2.7"
-- "3.5"
-- "3.6"
-- "3.7"
-- "3.8-dev"
-- "pypy"
-- "pypy3"
+  - "2.7"
+  - "3.5"
+  - "3.6"
+  - "3.7"
+  - "3.8-dev"
+  - "pypy"
+  - "pypy3"
 install:
-- pip install tox-travis codecov
-- if [[ $TOX_SUFFIX != 'lint' ]]; then python setup.py install ; fi
+  - pip install tox-travis codecov
+  - if [[ $TOX_SUFFIX != 'lint' ]]; then python setup.py install ; fi
 script:
-- tox -e "${TOX_SUFFIX}"
+  - tox -e "${TOX_SUFFIX}"
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 before_install: openssl version
 env:
@@ -15,46 +16,32 @@ matrix:
   include:
     - env: TOX_SUFFIX="lint"
       python: 3.7
-      dist: xenial
     - env: TOX_SUFFIX="requests"
       python: 3.7
-      dist: xenial
     - env: TOX_SUFFIX="httplib2"
       python: 3.7
-      dist: xenial
     - env: TOX_SUFFIX="boto3"
       python: 3.7
-      dist: xenial
     - env: TOX_SUFFIX="urllib3"
       python: 3.7
-      dist: xenial
     - env: TOX_SUFFIX="tornado4"
       python: 3.7
-      dist: xenial
     - env: TOX_SUFFIX="aiohttp"
       python: 3.7
-      dist: xenial
     - env: TOX_SUFFIX="lint"
       python: 3.8-dev
-      dist: xenial
     - env: TOX_SUFFIX="requests"
       python: 3.8-dev
-      dist: xenial
     - env: TOX_SUFFIX="httplib2"
       python: 3.8-dev
-      dist: xenial
     - env: TOX_SUFFIX="boto3"
       python: 3.8-dev
-      dist: xenial
     - env: TOX_SUFFIX="urllib3"
       python: 3.8-dev
-      dist: xenial
     - env: TOX_SUFFIX="tornado4"
       python: 3.8-dev
-      dist: xenial
     - env: TOX_SUFFIX="aiohttp"
       python: 3.8-dev
-      dist: xenial
   allow_failures:
     - env: TOX_SUFFIX="aiohttp"
       python: "pypy3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,57 +14,25 @@ env:
     - TOX_SUFFIX="aiohttp"
 matrix:
   include:
+    # Only run lint on a single 3.x
     - env: TOX_SUFFIX="lint"
-      python: 3.7
-    - env: TOX_SUFFIX="requests"
-      python: 3.7
-    - env: TOX_SUFFIX="httplib2"
-      python: 3.7
-    - env: TOX_SUFFIX="boto3"
-      python: 3.7
-    - env: TOX_SUFFIX="urllib3"
-      python: 3.7
-    - env: TOX_SUFFIX="tornado4"
-      python: 3.7
-    - env: TOX_SUFFIX="aiohttp"
-      python: 3.7
-    - env: TOX_SUFFIX="lint"
-      python: 3.8-dev
-    - env: TOX_SUFFIX="requests"
-      python: 3.8-dev
-    - env: TOX_SUFFIX="httplib2"
-      python: 3.8-dev
-    - env: TOX_SUFFIX="boto3"
-      python: 3.8-dev
-    - env: TOX_SUFFIX="urllib3"
-      python: 3.8-dev
-    - env: TOX_SUFFIX="tornado4"
-      python: 3.8-dev
-    - env: TOX_SUFFIX="aiohttp"
-      python: 3.8-dev
+      python: "3.7"
   allow_failures:
     - env: TOX_SUFFIX="aiohttp"
       python: "pypy3"
   exclude:
-    # Only run lint on a single 3.x
-    - env: TOX_SUFFIX="lint"
-      python: 2.7
-    - env: TOX_SUFFIX="lint"
-      python: 3.5
-    - env: TOX_SUFFIX="lint"
-      python: pypy
-    - env: TOX_SUFFIX="lint"
-      python: "pypy3"
     # Exclude aiohttp support
     - env: TOX_SUFFIX="aiohttp"
-      python: 2.7
+      python: "2.7"
     - env: TOX_SUFFIX="aiohttp"
-      python: pypy
+      python: "pypy"
 python:
-- 2.7
-- 3.5
-- 3.6
-- pypy
+- "2.7"
+- "3.5"
+- "3.6"
+- "3.7"
+- "3.8-dev"
+- "pypy"
 - "pypy3"
 install:
 - pip install tox-travis codecov


### PR DESCRIPTION
This updates the branch for PR https://github.com/kevin1024/vcrpy/pull/477.

Use `dist: xenial` for all.

This means 3.7 and 3.8-dev don't need to be added via `include` and can be part of the normal language matrix.

No change: lint should only run on a single 3.x version, so that's not included in the main `TOX_SUFFIX` matrix, and is in the extra `include` section.

Also consistently indent, and quote Python versions.